### PR TITLE
Hide navigation on zoomerang open

### DIFF
--- a/client/application/components/nav/_nav.scss
+++ b/client/application/components/nav/_nav.scss
@@ -1,4 +1,5 @@
 .nav {
+    position: absolute;
     width: 100%;
     height: $nav-height;
     background-color: $color-white;
@@ -7,13 +8,11 @@
     padding: 0 1rem;
     z-index: 10;
     @include user-select(none);
+    @include transition(.4s);
 
-    &.fixed {
-        position: fixed;
-    }
-
-    &:not(.fixed) {
-        position: absolute;
+    &.invisible {
+        opacity: 0;
+        @include transform(translateY(-100%));
     }
 
     .logo {

--- a/client/application/components/nav/nav.coffee
+++ b/client/application/components/nav/nav.coffee
@@ -1,0 +1,3 @@
+Template.nav.helpers
+	navigationOpen: ->
+		'invisible' if not Session.get('navigationOpen')

--- a/client/application/components/nav/nav.html
+++ b/client/application/components/nav/nav.html
@@ -1,5 +1,5 @@
 <template name="nav">
-	<nav class="fixed nav">
+	<nav class="nav {{ navigationOpen }}">
 		<a href="/" class="logo">{{ logo }}</a>
 		<button class="menu-toggler">
 			<span>Menu</span>

--- a/client/application/layouts/_layout.scss
+++ b/client/application/layouts/_layout.scss
@@ -41,6 +41,7 @@ main {
     height: 100%;
     min-height: 100vh;
     overflow: hidden;
+    background-color: #fff;
 
     padding-top: $nav-height;
     @include display(flex);

--- a/client/application/layouts/layout.coffee
+++ b/client/application/layouts/layout.coffee
@@ -32,16 +32,6 @@ Template.nav.events
 		menu = new Menu()
 		menu.toggle()
 
-Template.layout.rendered = ->
-	$window = $(window)
-	$nav    = $('nav')
-
-	$window.scroll ->
-		if $window.scrollTop() <= 0
-			$nav.addClass('fixed')
-		else
-			$nav.removeClass('fixed')
-
 Menu = () ->
 	$applicationContent = $('.applicationContent')
 	className           = 'menu-open'

--- a/client/lib/zoomerang.js
+++ b/client/lib/zoomerang.js
@@ -175,6 +175,8 @@
             lock = true
             parent = target.parentNode
 
+            Session.set('navigationOpen', false);
+
             var p     = target.getBoundingClientRect(),
                 scale = Math.min(options.maxWidth / p.width, options.maxHeight / p.height),
                 dx    = p.left - (window.innerWidth - p.width) / 2,
@@ -242,6 +244,8 @@
 
             if (!shown || lock) return
             lock = true
+
+            Session.set('navigationOpen', true);
 
             var p  = placeholder.getBoundingClientRect(),
                 dx = p.left - (window.innerWidth - p.width) / 2,

--- a/client/lib/zoomerang.js
+++ b/client/lib/zoomerang.js
@@ -31,7 +31,9 @@
         maxWidth: 300,
         maxHeight: 300,
         onOpen: null,
-        onClose: null
+        onClose: null,
+        onBeforeClose: null,
+        onBeforeOpen: null
     }
 
     // compatibility stuff
@@ -171,11 +173,12 @@
                 ? document.querySelector(el)
                 : el
 
+            // onBeforeOpen event
+            if (options.onBeforeOpen) options.onBeforeOpen(target)
+
             shown = true
             lock = true
             parent = target.parentNode
-
-            Session.set('navigationOpen', false);
 
             var p     = target.getBoundingClientRect(),
                 scale = Math.min(options.maxWidth / p.width, options.maxHeight / p.height),
@@ -245,7 +248,8 @@
             if (!shown || lock) return
             lock = true
 
-            Session.set('navigationOpen', true);
+            // onBeforeClose event
+            if (options.onBeforeClose) options.onBeforeClose(target)
 
             var p  = placeholder.getBoundingClientRect(),
                 dx = p.left - (window.innerWidth - p.width) / 2,

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -1,1 +1,3 @@
 Meteor.subscribe 'allUsers'
+
+Session.setDefault('navigationOpen', true)

--- a/client/modules/profile/profile.coffee
+++ b/client/modules/profile/profile.coffee
@@ -7,6 +7,13 @@ Template.profile.helpers
 		getFollower()
 
 Template.profile.rendered = ->
+	Zoomerang.config({
+		onBeforeOpen: ->
+			Session.set('navigationOpen', false)
+		onBeforeClose: ->
+			Session.set('navigationOpen', true)
+	})
+
 	Zoomerang.listen('#profile header .avatar img')
 
 Template.profile.events


### PR DESCRIPTION
This solves a bug that didn't close zoomerang when clicked on navigation.
Next to that, it just looks better.